### PR TITLE
Use item key as atomic View key

### DIFF
--- a/src/getBlocks.js
+++ b/src/getBlocks.js
@@ -140,7 +140,7 @@ const getBlocks = (params: ParamsType): ?Array<React$Element<*>> => {
             const atomic = atomicHandler(item, contentState.entityMap);
             if (viewBefore) {
               return (
-                <View key={generateKey()}>
+                <View key={item.key}>
                   {viewBefore}
                   {atomic}
                 </View>


### PR DESCRIPTION
Managed to reproduce the [bug](https://bootkik.atlassian.net/browse/KNOW-912) for processes that have steps created in the following scenario
    1. Add a list to your step description
    2. Add an image in one of the list items

In that case `getRNDraftJSBlocks` returns 
```
<View key={generateKey()}>
    {viewBefore}
    {atomic}
  </View>
```
instead of just the `atomic` component.

Since `atomic` in this case uses [AutoSizedImage](https://github.com/Manifest-Labs/knowhow-app/blob/develop/src/components/image/AutoSizedImage.js) the changes on its states (scalableWidth, scalableHeight, loading) re-renderers it which by consequence makes the component above (returned by `getRNDraftJSBlocks`) to re-render too. This was creating an infinite loop of renders. I tried to modify `AutoSizedImage` to avoid this behavior but couldn't find a way to do it so I had to modify the parent's key, making it unique per item, in order to avoid the loop.